### PR TITLE
More up-to-date OS X build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The root problem is that Windows doesn't make it easy to tap into whatever audio
 6. start cmake, point it to srcdir `soundview/`, builddir wherever
    - cmake should automatically find the correct locations for FFTW and SFML. If not, point it to wherever you have Homebrew set up to install them.
 7. start xcode, open `<builddir>/soundview.xcodeproj`
-8. run the build in xcode, success! now you just need to turn this into a usable binary. good luck! the problem is that the developer is trying to create the window somewhere other than the main thread, which doesn't work on OS X (all GUI stuff has to be done on the main thread in OS X). SFML detects this and refuses to even try, and because the program doesn't have a window it immediately exits.
+8. run the build in xcode, success! now you just need to turn this into a usable binary. good luck! the problem is that soundview tries to create the window in a worker thread, which doesn't work on OS X (all GUI stuff is required to be done on the main thread in OS X). SFML detects this and refuses to even try, and because the program doesn't have a window it immediately exits.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -136,17 +136,14 @@ The root problem is that Windows doesn't make it easy to tap into whatever audio
 1. clone git repo
 2. install xcode
 3. get cmake for osx
-4. download the fftw3 .deb provided by fink
-   - unpack .deb with `tar xzvf`
-   - then `tar xzvf data.tar.gz`
-   - see `sw/lib/libfftw<ver>.dylib`
-5. download sfml mac package. observe `/include` and `/lib/libsfml-*.dylib`
+4. download and install FFTW with homebrew:
+   - `brew install fftw`
+5. download and install SFML with homebrew:
+   - `brew install sfml`
 6. start cmake, point it to srcdir `soundview/`, builddir wherever
-   - fftw incl: `sw/include/`, fftw lib: `sw/lib/libfftw<ver>.dylib`
-   - sfml incl: `SFML-<ver>-osx-clang-universal/include/`, sfml libs: `SFML-<ver>-osx-clang-universal/lib/libsfml-*.<ver>.dylib`
-7. start xcode, hit tiny `Open another project...` button, pick `<builddir>/soundview.xcodeproj`
-8. run the build in xcode, success! now you just need to turn this into a usable binary. good luck!
-(this snowflake is harder to figure out than visual studio. docs PRs are welcome)
+   - cmake should automatically find the correct locations for FFTW and SFML. If not, point it to wherever you have Homebrew set up to install them.
+7. start xcode, open `<builddir>/soundview.xcodeproj`
+8. run the build in xcode, success! now you just need to turn this into a usable binary. good luck! the problem is that the developer is trying to create the window somewhere other than the main thread, which doesn't work on OS X (all GUI stuff has to be done on the main thread in OS X). SFML detects this and refuses to even try, and because the program doesn't have a window it immediately exits.
 
 ## Usage
 


### PR DESCRIPTION
Describes how to build soundview on OS X using Homebrew instead of Fink (no one uses Fink anymore).

Also provides details about why it will build but not run (I lack the C++ knowledge to fix this)
